### PR TITLE
CI/CD: CQ - ignore module imports not at top of file

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -3,6 +3,9 @@
 extend-select = [
     "N"
 ]
+extend-ignore = [
+    "E402",  # Module level import not at top of file
+]
 
 [lint.pep8-naming]
 extend-ignore-names = [


### PR DESCRIPTION
although it should mostly be avoided, there are good reasons for this, sometimes