### PR TITLE
feat(isu): implement STAC Table Extension exporter for SDI integration

### DIFF
--- a/subsystems/isu/sdi_output/exporter.py
+++ b/subsystems/isu/sdi_output/exporter.py
@@ -6,6 +6,7 @@ import io
 import pandas as pd
 from typing import Tuple, List, Dict
 
+
 class SDIExporter:
     """
     Exporter for STAC Table Extension (v1.2.0).
@@ -15,14 +16,16 @@ class SDIExporter:
 
     def __init__(self, logger):
         self.logger = logger
-        self.logger.debug("SDIExporter (STAC Table Extension) initialized.")
+        self.logger.debug('SDIExporter (STAC Table Extension) initialized.')
 
-    def create_sdi_package(self, df: pd.DataFrame, filename: str) -> Tuple[io.BytesIO, str]:
+    def create_sdi_package(
+        self, df: pd.DataFrame, filename: str
+    ) -> Tuple[io.BytesIO, str]:
         """
         Main workflow to package data and metadata into a ZIP buffer.
         """
         table_name = self._generate_table_name(filename)
-        self.logger.info(f"Generating STAC Table package for: {table_name}")
+        self.logger.info(f'Generating STAC Table package for: {table_name}')
 
         # 1. Standardize Timestamps to ISO 8601 (STAC Requirement)
         df = self._standardize_dataframe(df)
@@ -36,7 +39,9 @@ class SDIExporter:
         # 4. Create ZIP in memory
         zip_buffer = self._create_zip(df, stac_json)
 
-        self.logger.debug(f"Packaged {len(df.columns)} columns for table '{table_name}'.")
+        self.logger.debug(
+            f"Packaged {len(df.columns)} columns for table '{table_name}'."
+        )
         return zip_buffer, table_name
 
     def _standardize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -45,61 +50,62 @@ class SDIExporter:
         """
         # use 'iso_timestamp' as the standardized column from ParsingEngine
         if 'iso_timestamp' in df.columns:
-            df['iso_timestamp'] = pd.to_datetime(df['iso_timestamp']).dt.strftime('%Y-%m-%dT%H:%M:%SZ')
-        
+            df['iso_timestamp'] = pd.to_datetime(df['iso_timestamp']).dt.strftime(
+                '%Y-%m-%dT%H:%M:%SZ'
+            )
+
         return df
 
     def _build_column_definitions(self, df: pd.DataFrame) -> List[Dict]:
         """
-        Pure dynamic sensing logic. 
+        Pure dynamic sensing logic.
         Maps Pandas dtypes to STAC Table types without hardcoded sensor names.
         """
         cols = []
         for col_name in df.columns:
             dtype = str(df[col_name].dtype)
-            
+
             # Type Mapping Logic
-            if "int" in dtype or "float" in dtype:
-                stac_type = "number"
-            elif "datetime" in dtype or "timestamp" in col_name.lower():
-                stac_type = "datetime"
+            if 'int' in dtype or 'float' in dtype:
+                stac_type = 'number'
+            elif 'datetime' in dtype or 'timestamp' in col_name.lower():
+                stac_type = 'datetime'
             else:
-                stac_type = "string"
+                stac_type = 'string'
 
             # Construct the column metadata object
-            col_def = {
-                "name": col_name,
-                "type": stac_type
-            }
+            col_def = {'name': col_name, 'type': stac_type}
             cols.append(col_def)
-            
+
         return cols
 
-    def _generate_stac_table_json(self, table_name: str, column_definitions: List[Dict]) -> dict:
+    def _generate_stac_table_json(
+        self, table_name: str, column_definitions: List[Dict]
+    ) -> dict:
         """
         Constructs the STAC Item JSON using the Table Extension schema.
         """
         return {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "stac_extensions": [
-                "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+            'type': 'Feature',
+            'stac_version': '1.0.0',
+            'stac_extensions': [
+                'https://stac-extensions.github.io/table/v1.2.0/schema.json'
             ],
-            "id": f"isu_{uuid.uuid4().hex[:8]}",
-            "properties": {
-                "datetime": pd.Timestamp.now(tz='UTC').isoformat(),
-                "table:row_count": None 
+            'id': f'isu_{uuid.uuid4().hex[:8]}',
+            'properties': {
+                'datetime': pd.Timestamp.now(tz='UTC').isoformat(),
+                'table:row_count': None,
             },
-            "geometry": None,
-            "assets": {
-                "data": {
+            'geometry': None,
+            'assets': {
+                'data': {
                     # The table name is routed via the href fragment (#)
-                    "href": f"postgresql://postgis:5432/geodata#{table_name}",
-                    "type": "text/csv",
-                    "roles": ["data"],
-                    "table:columns": column_definitions
+                    'href': f'postgresql://postgis:5432/geodata#{table_name}',
+                    'type': 'text/csv',
+                    'roles': ['data'],
+                    'table:columns': column_definitions,
                 }
-            }
+            },
         }
 
     def _create_zip(self, df: pd.DataFrame, stac_json: dict) -> io.BytesIO:
@@ -110,10 +116,10 @@ class SDIExporter:
         with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
             # 1. Wide-Format CSV
             zf.writestr('data.csv', df.to_csv(index=False))
-            
+
             # 2. Metadata JSON
             zf.writestr('metadata.json', json.dumps(stac_json, indent=4))
-        
+
         zip_buffer.seek(0)
         return zip_buffer
 
@@ -123,4 +129,4 @@ class SDIExporter:
         """
         base_name = os.path.splitext(filename)[0].lower()
         sanitized = base_name.replace('-', '_').replace('.', '_')
-        return f"isu_{sanitized}"
+        return f'isu_{sanitized}'


### PR DESCRIPTION
Overview
Added sdi_output/exporter.py using STAC Table Extension (v1.2.0).
To bridge ISU and SDI subsystems.
Key Changes
1.Wide-Format: Replaces Long-Format for better data structure.
2.Dynamic Metadata: Auto-generates table:columns from DataFrame.
3.ISO 8601: Enforces high-precision timestamps for TIMESTAMPTZ.
4.In-Memory: Uses io.BytesIO for ZIP packaging.