### PR TITLE
ISU tests: fix imports of the ISU subsystem

### DIFF
--- a/subsystems/isu/tests/test_scheduler.py
+++ b/subsystems/isu/tests/test_scheduler.py
@@ -3,7 +3,7 @@
 import time
 import pytest
 from unittest.mock import MagicMock
-from subsystems.isu.scheduler import Scheduler
+from isu.scheduler import Scheduler
 
 
 @pytest.fixture

--- a/subsystems/isu/tests/test_subsystem.py
+++ b/subsystems/isu/tests/test_subsystem.py
@@ -8,7 +8,7 @@ import shutil
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-from subsystems.isu import InSituDataUploader
+from isu import InSituDataUploader
 
 TEST_DATA_DIR = Path(__file__).parent / 'test_data'
 


### PR DESCRIPTION
just like in a064f9f, the imports are done from the `subsystems` directory inside the docker - therefore, they should not contain the `subsystems` inside the import path