### PR TITLE
Update pandas/shapely to the most recent versions

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -7,7 +7,7 @@ psycopg==3.2.13  # sdi
 psycopg2==2.9.11  # sdi
 psycopg_pool==3.2.8  # sdi
 eodag==3.10.1 # eou
-pandas==2.3.3 # isu
+pandas==3.0.1 # isu
 openpyxl==3.1.5 # isu
 pyyaml==6.0.3 # lib.config
-shapely==2.0.7 # lib.config
+shapely==2.1.2 # lib.config


### PR DESCRIPTION
Pandas/Shapely versions used by docker image have been downgraded because of base image (old-stable Debian). Can be updated thanks to #126.