### PR TITLE
DPR vs SDI: fix incompatible datetime format in metadata

### DIFF
--- a/subsystems/dpr/metadata_processor/generator.py
+++ b/subsystems/dpr/metadata_processor/generator.py
@@ -186,7 +186,7 @@ class StacItemFactory:
         :rtype: dict
         """
         item_id = self.raster.path.stem
-        now = datetime.now(UTC).isoformat() + 'Z'
+        now = datetime.now(UTC).isoformat()
 
         bbox = self.raster.get_bbox_wgs84()
         geometry = self._build_geometry(bbox)


### PR DESCRIPTION
* SDI does not accept datetime format with the Zulu time specified. This fixes it
* As the tests for DPR skip datetime check, this should not break any tests
* @landam, @janruzicka-cybele: Is it fine with you to skip the `Z` at the end of the string? I have absolutely no opinion on that.