### PR TITLE
feat(ISU): integrate QCL and DPR

### DIFF
--- a/subsystems/isu/__init__.py
+++ b/subsystems/isu/__init__.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Any, Optional
 
 from lib.base import GaiaBase, SubsystemId
+from subsystems.qcl import QCLayer
 
 # Import the four core modules
 from .etl_engine.pipeline import ETLEngine
@@ -13,17 +14,34 @@ class InSituDataUploader(GaiaBase):
     """
     GAIA-TSF Prototype: In-Situ Data Uploader (ISU) Subsystem.
 
-    Acts as the **Facade** for the ISU module. It is responsible for initializing 
-    and managing data ingestion through three concurrent methods: manual upload, 
-    scheduled background bulk scanning, and real-time streaming. All ingested 
+    Acts as the **Facade** for the ISU module. It is responsible for initializing
+    and managing data ingestion through three concurrent methods: manual upload,
+    scheduled background bulk scanning, and real-time streaming. All ingested
     data is routed to the central ETL Engine for unified processing.
 
+    External Interfaces:
+    - **ISU_I_1 → DPR**: An optional ``dpr_service`` (``DataProcessing`` instance)
+      is injected to receive validated and standardised datasets for downstream
+      processing. SDI integration is achieved indirectly through this interface
+      (ISU_R_07: raw data is converted to SDI-compatible objects before handoff).
+    - **ISU_I_2 → QCL**: A ``QCLayer`` instance is created internally and injected
+      into the ETL Engine and StreamingDataHandler. ISU reports ingestion status,
+      validation results, and error metadata to QCL as structured events.
+
+    Note: ISU has **no direct interface with SDI**. SDI integration is indirect,
+    via the data products and metadata delivered to DPR through ISU_I_1.
+
     :param project_file: Optional path to a specific project configuration file.
-                         Inherited and handled by GaiaBase.
     :type project_file: Optional[str]
+    :param dpr_service: Optional Data Processing subsystem instance (ISU_I_1).
+    :type dpr_service: Any
     """
 
-    def __init__(self, project_file: Optional[str] = None):
+    def __init__(
+        self,
+        project_file: Optional[str] = None,
+        dpr_service: Any = None,
+    ):
         """
         Initialize the InSituDataUploader subsystem and its sub-components.
         """
@@ -32,15 +50,24 @@ class InSituDataUploader(GaiaBase):
 
         self.logger.info("Initializing ISU Subsystem driven by GaiaBase...")
 
-        # 2. Configurations are now handled internally by sub-modules via GaiaBase
-        
+        # 2. ISU_I_2: Wire QCL — instantiate and own the Quality Control layer.
+        # QCL receives ingestion status, validation results, and error reports.
+        self.qc_layer = QCLayer()
+        self.logger.debug("QCLayer (ISU_I_2) wired into ISU.")
 
-        # 3. Initialize the core hub: ETL Engine
-        # The engine serves as the central processing unit for all three data streams
-        self.etl_engine = ETLEngine(project_file=project_file)
+        # 3. ISU_I_1: Store the optional DPR service reference.
+        # SDI integration is indirect: ISU converts raw data to SDI-compatible
+        # objects (ISU_R_07) and delivers them to DPR, which handles SDI ingestion.
+        self.dpr_service = dpr_service
 
-        # 4. Initialize the three parallel ingestion entries
-        # The ETL Engine (or its callback) is injected into each loader/handler
+        # 4. Initialize the core hub: ETL Engine with all service dependencies
+        self.etl_engine = ETLEngine(
+            project_file=project_file,
+            qc_layer=self.qc_layer,
+            dpr_service=self.dpr_service,
+        )
+
+        # 5. Initialize the three parallel ingestion entries
         self.manual_loader = ManualFileLoader(
             etl_engine=self.etl_engine,
             project_file=project_file
@@ -53,6 +80,7 @@ class InSituDataUploader(GaiaBase):
 
         self.stream_handler = StreamingDataHandler(
             etl_callback=self.etl_engine.process_data,
+            qc_layer=self.qc_layer,
             project_file=project_file
         )
 

--- a/subsystems/isu/etl_engine/parsers/__init__.py
+++ b/subsystems/isu/etl_engine/parsers/__init__.py
@@ -87,6 +87,7 @@ class ParsingEngine:
                 'row_count': len(parsed_df),
                 'columns': list(parsed_df.columns),
                 'data_preview': parsed_df.head(5).to_dict(orient='records'),
+                'data': parsed_df
             }
 
         except (ValueError, IOError) as e:

--- a/subsystems/isu/etl_engine/pipeline.py
+++ b/subsystems/isu/etl_engine/pipeline.py
@@ -20,16 +20,24 @@ class ETLEngine(GaiaBase):
     :type qc_layer: Any
     """
     
-    def __init__(self, project_file: Optional[str] = None, qc_layer: Any = None):
+    def __init__(
+        self,
+        project_file: Optional[str] = None,
+        qc_layer: Any = None,
+        dpr_service: Any = None,
+    ):
         """
         Initialize the ETLEngine using GaiaBase.
         """
         # Step 1: Initialize base class and register subsystem identity as ISU
         super().__init__(SubsystemId.ISU, project_file=project_file)
-        
-        # Dependency Injection: Receive the QC layer instance
+
+        # Dependency Injection: Receive external service instances
+        # qc_layer  → ISU_I_2: Quality Control and Logging (QCL)
+        # dpr_service → ISU_I_1: Data Processing (DPR); SDI is reached indirectly via DPR
         self.qc_layer = qc_layer
-        
+        self.dpr_service = dpr_service
+
         # Step 2: Utilize self.logger automatically provided by GaiaBase
         self.parsing_engine = ParsingEngine(logger=self.logger)
         self.logger.info("ETL Engine initialized with ParsingEngine.")
@@ -100,10 +108,23 @@ class ETLEngine(GaiaBase):
                 self.logger.warning("No QC layer configured. Skipping quality control.")
                 qc_result = {'final_status': 'Skipped (No QC Layer)'}
 
+            # ISU_I_1: Route validated, standardised dataset to DPR (ISU_IR_02 / ISU_R_07).
+            # SDI integration is indirect — DPR is responsible for SDI ingestion.
+            if self.dpr_service:
+                dpr_result = self.dpr_service.process_in_situ(df, metadata)
+                self.logger.info(
+                    f"[ISU_I_1] Dataset '{filename}' delivered to DPR: "
+                    f"ready_for_sdi={dpr_result.get('ready_for_sdi')}"
+                )
+            else:
+                self.logger.warning("No DPR service configured (ISU_I_1). Skipping data processing.")
+                dpr_result = {'status': 'Skipped (No DPR Service)', 'ready_for_sdi': False}
+
             # Return standardized payload for external interfaces (ISU_R_07)
             return {
                 'metadata': metadata,
                 'qc_result': qc_result,
+                'dpr_result': dpr_result,
                 'data': df
             }
         else:
@@ -127,17 +148,18 @@ class ETLEngine(GaiaBase):
         """
         sensor_type = metadata.get('sensor_type', 'unknown')
         dataset_id = metadata.get('source_topic_or_stream', 'unknown_stream')
-        
+
         self.logger.info(f"ETL Engine received valid streaming payload from {sensor_type} ({dataset_id}).")
-        
-        # Log data shape and QC status. 
-        # Note: In a production environment, this triggers the DPR_I_1 interface 
-        # to dispatch data to the external Data Processor.
-        self.logger.debug(
-            f"Stream data shape: {df.shape}, "
-            f"QC Status: {qc_result.get('final_status')}"
-        )
-        
-        # Integration Hook: Place logic here for downstream handoff.
-        # Example: self.dpr_service.send_to_processor(df, metadata)
-        pass
+        self.logger.debug(f"Stream data shape: {df.shape}, QC Status: {qc_result.get('final_status')}")
+
+        # ISU_I_1: Route validated, standardised streaming dataset to DPR (ISU_IR_02 / ISU_R_07).
+        # SDI integration is indirect — DPR is responsible for SDI ingestion.
+        if self.dpr_service:
+            dpr_result = self.dpr_service.process_in_situ(df, metadata)
+            self.logger.info(
+                f"[ISU_I_1] Stream data from {dataset_id} delivered to DPR: "
+                f"ready_for_sdi={dpr_result.get('ready_for_sdi')}"
+            )
+        else:
+            self.logger.warning("No DPR service configured (ISU_I_1). Skipping data processing.")
+            dpr_result = {'status': 'Skipped (No DPR Service)', 'ready_for_sdi': False}

--- a/subsystems/isu/tests/test_interfaces.py
+++ b/subsystems/isu/tests/test_interfaces.py
@@ -1,21 +1,77 @@
-class TestInterfaces:
-    def test_IF1_001(self):
-        """Test IF1 DataProcessor.
+"""
+Integration tests for ISU external interfaces.
 
-        Example of integration test.
-        """
-        pass
+ISU_I_1 → DPR (DataProcessing): ISU delivers validated, standardised datasets
+  to DPR via process_in_situ(). SDI integration is indirect through DPR (ISU_R_07).
+
+ISU_I_2 → QCL (QualityControlLogging): ISU reports ingestion status, validation
+  results, and error metadata to QCL as structured events via qc_layer.check().
+"""
+
+import pandas as pd
+from unittest.mock import MagicMock
+
+from subsystems.isu.etl_engine.pipeline import ETLEngine
+
+
+# Minimal CSV payload that triggers SlopeStabilityParser (score > 0.6)
+_SLOPE_CSV = b"timestamp,displacement\n2024-01-01T00:00:00Z,0.5\n2024-01-02T00:00:00Z,0.6"
+_SLOPE_FILENAME = "slope_sensor_data.csv"
+
+
+class TestInterfaces:
+
+    # ------------------------------------------------------------------
+    # ISU_I_1 – DPR (DataProcessor)
+    # ISU_IR_02: deliver validated and standardised datasets to DPR
+    # ISU_R_07: raw data converted to SDI-compatible objects before handoff
+    # ------------------------------------------------------------------
+
+    def test_IF1_001(self):
+        """ISU_I_1: ETLEngine delivers a parsed file to DPR via process_in_situ()."""
+        mock_dpr = MagicMock()
+        mock_dpr.process_in_situ.return_value = {'status': 'processed', 'ready_for_sdi': True}
+
+        engine = ETLEngine(dpr_service=mock_dpr)
+        result = engine.process_file(_SLOPE_CSV, _SLOPE_FILENAME)
+
+        mock_dpr.process_in_situ.assert_called_once()
+        assert result is not None
+        assert result['dpr_result']['ready_for_sdi'] is True
 
     def test_IF1_002(self):
-        """Test IF1 DataProcessor.
+        """ISU_I_1: ETLEngine delivers streaming data to DPR via process_in_situ()."""
+        mock_dpr = MagicMock()
+        mock_dpr.process_in_situ.return_value = {'status': 'processed', 'ready_for_sdi': True}
 
-        Another example of integration test.
-        """
-        pass
+        engine = ETLEngine(dpr_service=mock_dpr)
+
+        df = pd.DataFrame([{'timestamp': '2024-01-01', 'displacement': 0.5}])
+        metadata = {
+            'sensor_type': 'slope',
+            'source_topic_or_stream': 'test_stream',
+            'ingestion_mode': 'streaming',
+        }
+        qc_result = {'final_status': 'Pass'}
+
+        engine.process_data(df, metadata, qc_result)
+
+        mock_dpr.process_in_situ.assert_called_once_with(df, metadata)
+
+    # ------------------------------------------------------------------
+    # ISU_I_2 – QCL (QualityControlLogging)
+    # ISU_IR_03: report ingestion status, errors, and metadata to QCL
+    # ------------------------------------------------------------------
 
     def test_IF2_001(self):
-        """Test IF2 QualityControlLogging Layer.
+        """ISU_I_2: ETLEngine calls qc_layer.check() with correct data_type and dataset_id."""
+        mock_qc = MagicMock()
+        mock_qc.check.return_value = {'final_status': 'Pass', 'errors': []}
 
-        Example of integration test.
-        """
-        pass
+        engine = ETLEngine(qc_layer=mock_qc)
+        engine.process_file(_SLOPE_CSV, _SLOPE_FILENAME)
+
+        mock_qc.check.assert_called_once()
+        _, kwargs = mock_qc.check.call_args
+        assert kwargs['data_type'] == 'in_situ'
+        assert kwargs['dataset_id'] == _SLOPE_FILENAME


### PR DESCRIPTION
integrate QCL and DPR interfaces per ISU_IR_02 and ISU_IR_03

1. ISU_I_2 (QCL): Wire QCLayer into ISU facade and ETLEngine for automatic quality gatekeeping on all ingested data (ISU_IR_03)
2. ISU_I_1 (DPR): Extend ETLEngine to deliver validated, standardised datasets to dpr_service via process_in_situ(), covering both file and streaming paths (ISU_IR_02 / ISU_R_07)
3. Replace process_data() stub with real DPR dispatch logic
4. No direct SDI interface: SDI integration is indirect through DPR (ISU_R_07)
5. Add integration tests for IF1 (DPR) and IF2 (QCL) interfaces