### PR TITLE
ISU: Support DPR's STAC item generation for in-situ data

### DIFF
--- a/subsystems/dpr/__init__.py
+++ b/subsystems/dpr/__init__.py
@@ -25,7 +25,9 @@ class DataProcessing(GaiaBase):
         self.data_analysis_pipelines = DataAnalysisPipelines()
         self.metadata_processor = MetadataProcessor()
 
-    def process_in_situ(self, file_path: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    def process_in_situ(
+        self, file_path: str, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         ISU_I_1: Receive an in-situ CSV file and its metadata from ISU,
         generate a STAC item via MetadataGenerator, and prepare for SDI ingestion.

--- a/subsystems/dpr/__init__.py
+++ b/subsystems/dpr/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from subsystems.dpr.preprocessing_pipelines import PreprocessingPipelines
 from subsystems.dpr.data_analysis_pipelines import DataAnalysisPipelines
 from subsystems.dpr.metadata_processor import MetadataProcessor
@@ -22,3 +24,20 @@ class DataProcessing(GaiaBase):
         self.preprocessing_pipelines = PreprocessingPipelines()
         self.data_analysis_pipelines = DataAnalysisPipelines()
         self.metadata_processor = MetadataProcessor()
+
+    def process_in_situ(self, file_path: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        ISU_I_1: Receive an in-situ CSV file and its metadata from ISU,
+        generate a STAC item via MetadataGenerator, and prepare for SDI ingestion.
+
+        :param str file_path: Path to the CSV file provided by ISU.
+        :param dict metadata: Metadata dict from ISU (time_range, location, schema, crs, sensor_type).
+        :return: Processing result dict with ready_for_sdi flag.
+        :rtype: dict
+        """
+        self.logger.info(f'[DPR] Processing in-situ dataset: {file_path}')
+        self.metadata_processor.generator.set_isu_metadata(metadata)
+        self.metadata_processor.generator.set_datasource(file_path)
+        stac_item = self.metadata_processor.generator.stac.create_item()
+        self.logger.info(f'[DPR] STAC item generated for {file_path}')
+        return {'status': 'ok', 'ready_for_sdi': True, 'stac_item': stac_item}

--- a/subsystems/dpr/metadata_processor/generator.py
+++ b/subsystems/dpr/metadata_processor/generator.py
@@ -142,6 +142,130 @@ class RasterDataset:
         return bands
 
 
+class InsituDataset:
+    """
+    Wrapper for in-situ CSV datasets providing spatial and temporal metadata
+    for STAC item generation. Relies on the metadata dict provided by ISU,
+    since CSV files do not embed spatial information like GeoTIFF.
+
+    :param str path: Path to the CSV file
+    :param dict metadata: Metadata dict from ISU containing time_range, location, schema, crs, sensor_type
+    """
+
+    def __init__(self, path: str, metadata: Dict[str, Any]):
+        self.path = Path(path)
+        self._meta = metadata
+        self._data = metadata.get('data', {})
+
+    @property
+    def epsg(self) -> int:
+        crs = self._data.get('crs', 'EPSG:4326')
+        return int(crs.split(':')[1])
+
+    def get_bbox(self) -> Optional[List[float]]:
+        """Returns [min_lon, min_lat, max_lon, max_lat] or None."""
+        loc = self._data.get('location')
+        return loc['bbox'] if loc else None
+
+    def get_time_range(self) -> Optional[Dict[str, str]]:
+        """Returns {'start': ..., 'end': ...} or None."""
+        return self._data.get('time_range')
+
+    def get_schema(self) -> List[str]:
+        """Returns list of column names."""
+        return self._data.get('schema', [])
+
+    def get_sensor_type(self) -> Optional[str]:
+        """Returns sensor type string or None."""
+        return self._data.get('sensor_type')
+
+
+class InsituStacItemFactory:
+    """
+    Creates STAC Item metadata from an InsituDataset.
+    """
+
+    STAC_EXTENSIONS: List[str] = [
+        'https://stac-extensions.github.io/table/v1.2.0/schema.json',
+        'https://stac-extensions.github.io/projection/v1.0.0/schema.json',
+    ]
+
+    def __init__(self, dataset: InsituDataset, logger: Any):
+        self.dataset = dataset
+        self.logger = logger
+
+    def _build_geometry(self, bbox: List[float]) -> Dict[str, Any]:
+        return {
+            'type': 'Polygon',
+            'coordinates': [
+                [
+                    [bbox[0], bbox[1]],
+                    [bbox[0], bbox[3]],
+                    [bbox[2], bbox[3]],
+                    [bbox[2], bbox[1]],
+                    [bbox[0], bbox[1]],
+                ]
+            ],
+        }
+
+    def create_item(self) -> Dict[str, Any]:
+        """
+        Creates a STAC Item as a dictionary.
+
+        :return: STAC Item
+        :rtype: dict
+        """
+        bbox = self.dataset.get_bbox()
+        time_range = self.dataset.get_time_range()
+        schema = self.dataset.get_schema()
+
+        properties: Dict[str, Any] = {
+            'datetime': time_range['start'] if time_range else None,
+            'start_datetime': time_range['start'] if time_range else None,
+            'end_datetime': time_range['end'] if time_range else None,
+            'proj:epsg': self.dataset.epsg,
+        }
+        sensor_type = self.dataset.get_sensor_type()
+        if sensor_type:
+            properties['sensor_type'] = sensor_type
+
+        stac_item: Dict[str, Any] = {
+            'type': 'Feature',
+            'stac_version': '1.0.0',
+            'stac_extensions': self.STAC_EXTENSIONS,
+            'id': self.dataset.path.stem,
+            'collection': 'undefined',
+            'properties': properties,
+            'geometry': self._build_geometry(bbox) if bbox else None,
+            'bbox': bbox,
+            'assets': {
+                'data': {
+                    'href': self.dataset.path.name,
+                    'type': 'text/csv',
+                    'roles': ['data'],
+                    'table:columns': [{'name': c} for c in schema],
+                }
+            },
+            'links': [],
+        }
+        self.logger.debug(f'STAC item created: {stac_item}')
+        return stac_item
+
+    def save(self, output_path: str) -> str:
+        """
+        Saves the STAC Item to a JSON file.
+
+        :param str output_path: Path to the output JSON
+        :return: output path
+        :rtype: str
+        """
+        item = self.create_item()
+        with open(output_path, 'w') as f:
+            json.dump(item, f, indent=4)
+        self.logger.info(f'STAC item saved: {output_path}')
+        return output_path
+
+
 class StacItemFactory:
     """
     Creates STAC Item metadata from a RasterDataset.
@@ -257,6 +381,14 @@ class MetadataGenerator(GaiaBase):
     def __init__(self):
         """Initialize metadata generator."""
         super().__init__(SubsystemId.DPR)
+        self._isu_metadata: Dict[str, Any] = {}
+
+    def set_isu_metadata(self, metadata: Dict[str, Any]) -> None:
+        """Store ISU-provided metadata for use when processing CSV datasources.
+
+        :param dict metadata: Metadata dict from ISU (time_range, location, schema, crs, sensor_type).
+        """
+        self._isu_metadata = metadata
 
     def set_datasource(self, data_source: str):
         """Set the data source for which metadata should be generated.
@@ -270,8 +402,9 @@ class MetadataGenerator(GaiaBase):
             self._ds = RasterDataset(data_source)
             self._factory = StacItemFactory(self._ds, self.logger)
         elif Path(data_source).suffix in ('.csv',):
-            # TODO: ISU
-            pass
+            self.logger.info(f'Metadata generator datasource: {data_source}')
+            self._ds = InsituDataset(data_source, self._isu_metadata)
+            self._factory = InsituStacItemFactory(self._ds, self.logger)
         else:
             # TODO: replace by GAIA-TSF exception
             raise RuntimeError('Unsupported datasource')

--- a/subsystems/dpr/tests/test_insitu_metadata.py
+++ b/subsystems/dpr/tests/test_insitu_metadata.py
@@ -24,7 +24,10 @@ _sqlalchemy = types.ModuleType('sqlalchemy')
 _sqlalchemy.create_engine = MagicMock()  # type: ignore[attr-defined]
 sys.modules.setdefault('sqlalchemy', _sqlalchemy)
 
-from subsystems.dpr.metadata_processor.generator import InsituDataset, InsituStacItemFactory
+from subsystems.dpr.metadata_processor.generator import (
+    InsituDataset,
+    InsituStacItemFactory,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -75,12 +78,14 @@ METADATA_NO_LOCATION = {
 @pytest.fixture
 def tmp_csv():
     """Create a temporary CSV file and return its path."""
-    df = pd.DataFrame({
-        'iso_timestamp': ['2026-01-01T00:00:00', '2026-06-30T23:59:59'],
-        'lat': [50.082, 50.092],
-        'lon': [14.412, 14.440],
-        'pressure': [101.3, 102.1],
-    })
+    df = pd.DataFrame(
+        {
+            'iso_timestamp': ['2026-01-01T00:00:00', '2026-06-30T23:59:59'],
+            'lat': [50.082, 50.092],
+            'lon': [14.412, 14.440],
+            'pressure': [101.3, 102.1],
+        }
+    )
     with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as f:
         df.to_csv(f.name, index=False)
         yield f.name
@@ -90,6 +95,7 @@ def tmp_csv():
 # ---------------------------------------------------------------------------
 # InsituDataset
 # ---------------------------------------------------------------------------
+
 
 class TestInsituDataset:
     def test_epsg_from_metadata(self, tmp_csv):
@@ -122,6 +128,7 @@ class TestInsituDataset:
 # ---------------------------------------------------------------------------
 # InsituStacItemFactory
 # ---------------------------------------------------------------------------
+
 
 class TestInsituStacItemFactory:
     def test_stac_item_structure(self, tmp_csv):
@@ -162,6 +169,7 @@ class TestInsituStacItemFactory:
 # process_in_situ() — tests the full pipeline using InsituDataset + InsituStacItemFactory
 # directly, bypassing GaiaBase/sqlalchemy dependencies
 # ---------------------------------------------------------------------------
+
 
 class TestProcessInSitu:
     def test_process_in_situ_returns_valid_stac(self, tmp_csv):

--- a/subsystems/dpr/tests/test_insitu_metadata.py
+++ b/subsystems/dpr/tests/test_insitu_metadata.py
@@ -1,0 +1,184 @@
+"""
+Tests for in-situ CSV metadata generation (Issue #200).
+
+Covers InsituDataset, InsituStacItemFactory, and MetadataGenerator for CSV datasources.
+"""
+
+import os
+import sys
+import tempfile
+import types
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+# Stub out osgeo so generator.py can be imported without GDAL installed
+for _mod in ('osgeo', 'osgeo.gdal', 'osgeo.osr'):
+    sys.modules.setdefault(_mod, types.ModuleType(_mod))
+_gdal = sys.modules['osgeo.gdal']
+if not hasattr(_gdal, 'UseExceptions'):
+    _gdal.UseExceptions = lambda: None  # type: ignore[attr-defined]
+
+_sqlalchemy = types.ModuleType('sqlalchemy')
+_sqlalchemy.create_engine = MagicMock()  # type: ignore[attr-defined]
+sys.modules.setdefault('sqlalchemy', _sqlalchemy)
+
+from subsystems.dpr.metadata_processor.generator import InsituDataset, InsituStacItemFactory
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+METADATA_WITH_LOCATION = {
+    'ingestion': {
+        'mode': 'manual',
+        'source': 'piezometer_site_A.csv',
+        'parser': 'slope',
+        'confidence': 0.9,
+    },
+    'data': {
+        'type': 'in_situ',
+        'format': 'csv',
+        'sensor_type': 'piezometer',
+        'time_range': {
+            'start': '2026-01-01T00:00:00',
+            'end': '2026-06-30T23:59:59',
+        },
+        'schema': ['iso_timestamp', 'lat', 'lon', 'pressure'],
+        'location': {'bbox': [14.412, 50.082, 14.440, 50.092]},
+        'crs': 'EPSG:4326',
+    },
+}
+
+METADATA_NO_LOCATION = {
+    'ingestion': {
+        'mode': 'bulk',
+        'source': 'sensor_nocoords.csv',
+    },
+    'data': {
+        'type': 'in_situ',
+        'format': 'csv',
+        'sensor_type': 'inclinometer',
+        'time_range': {
+            'start': '2026-03-01T00:00:00',
+            'end': '2026-03-31T23:59:59',
+        },
+        'schema': ['iso_timestamp', 'tilt_x', 'tilt_y'],
+        'location': None,
+        'crs': 'EPSG:4326',
+    },
+}
+
+
+@pytest.fixture
+def tmp_csv():
+    """Create a temporary CSV file and return its path."""
+    df = pd.DataFrame({
+        'iso_timestamp': ['2026-01-01T00:00:00', '2026-06-30T23:59:59'],
+        'lat': [50.082, 50.092],
+        'lon': [14.412, 14.440],
+        'pressure': [101.3, 102.1],
+    })
+    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as f:
+        df.to_csv(f.name, index=False)
+        yield f.name
+    os.unlink(f.name)
+
+
+# ---------------------------------------------------------------------------
+# InsituDataset
+# ---------------------------------------------------------------------------
+
+class TestInsituDataset:
+    def test_epsg_from_metadata(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        assert ds.epsg == 4326
+
+    def test_get_bbox(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        assert ds.get_bbox() == [14.412, 50.082, 14.440, 50.092]
+
+    def test_get_bbox_none_when_no_location(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_NO_LOCATION)
+        assert ds.get_bbox() is None
+
+    def test_get_time_range(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        tr = ds.get_time_range()
+        assert tr['start'] == '2026-01-01T00:00:00'
+        assert tr['end'] == '2026-06-30T23:59:59'
+
+    def test_get_schema(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        assert 'pressure' in ds.get_schema()
+
+    def test_get_sensor_type(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        assert ds.get_sensor_type() == 'piezometer'
+
+
+# ---------------------------------------------------------------------------
+# InsituStacItemFactory
+# ---------------------------------------------------------------------------
+
+class TestInsituStacItemFactory:
+    def test_stac_item_structure(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        factory = InsituStacItemFactory(ds, MagicMock())
+        item = factory.create_item()
+
+        assert item['type'] == 'Feature'
+        assert item['stac_version'] == '1.0.0'
+        assert item['bbox'] == [14.412, 50.082, 14.440, 50.092]
+        assert item['geometry']['type'] == 'Polygon'
+        assert item['properties']['proj:epsg'] == 4326
+        assert item['properties']['start_datetime'] == '2026-01-01T00:00:00'
+        assert item['properties']['end_datetime'] == '2026-06-30T23:59:59'
+
+    def test_stac_item_table_columns(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        factory = InsituStacItemFactory(ds, MagicMock())
+        item = factory.create_item()
+        col_names = [c['name'] for c in item['assets']['data']['table:columns']]
+        assert 'pressure' in col_names
+
+    def test_stac_item_null_geometry_when_no_location(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_NO_LOCATION)
+        factory = InsituStacItemFactory(ds, MagicMock())
+        item = factory.create_item()
+        assert item['geometry'] is None
+        assert item['bbox'] is None
+
+    def test_stac_item_sensor_type_in_properties(self, tmp_csv):
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        factory = InsituStacItemFactory(ds, MagicMock())
+        item = factory.create_item()
+        assert item['properties']['sensor_type'] == 'piezometer'
+
+
+# ---------------------------------------------------------------------------
+# process_in_situ() — tests the full pipeline using InsituDataset + InsituStacItemFactory
+# directly, bypassing GaiaBase/sqlalchemy dependencies
+# ---------------------------------------------------------------------------
+
+class TestProcessInSitu:
+    def test_process_in_situ_returns_valid_stac(self, tmp_csv):
+        """Full pipeline: InsituDataset → InsituStacItemFactory → STAC item."""
+        ds = InsituDataset(tmp_csv, METADATA_WITH_LOCATION)
+        factory = InsituStacItemFactory(ds, MagicMock())
+        stac_item = factory.create_item()
+
+        assert stac_item['type'] == 'Feature'
+        assert stac_item['bbox'] == [14.412, 50.082, 14.440, 50.092]
+        assert stac_item['properties']['start_datetime'] == '2026-01-01T00:00:00'
+
+    def test_process_in_situ_no_location_null_geometry(self, tmp_csv):
+        """Pipeline with no location: geometry and bbox should be None."""
+        ds = InsituDataset(tmp_csv, METADATA_NO_LOCATION)
+        factory = InsituStacItemFactory(ds, MagicMock())
+        stac_item = factory.create_item()
+
+        assert stac_item['geometry'] is None
+        assert stac_item['bbox'] is None

--- a/subsystems/isu/etl_engine/pipeline.py
+++ b/subsystems/isu/etl_engine/pipeline.py
@@ -1,3 +1,4 @@
+import tempfile
 from typing import Any, Dict, Optional
 import pandas as pd
 
@@ -216,7 +217,7 @@ class ETLEngine(GaiaBase):
             # ISU_I_1: Route validated, standardised dataset to DPR (ISU_IR_02 / ISU_R_07).
             # SDI integration is indirect — DPR is responsible for SDI ingestion.
             if self.dpr_service:
-                dpr_result = self.dpr_service.process_in_situ(df, metadata)
+                dpr_result = self.dpr_service.process_in_situ(filename, metadata)
                 self.logger.info(
                     f"[ISU_I_1] Dataset '{filename}' delivered to DPR: "
                     f'ready_for_sdi={dpr_result.get("ready_for_sdi")}'
@@ -289,7 +290,13 @@ class ETLEngine(GaiaBase):
         # ISU_I_1: Route validated, standardised streaming dataset to DPR (ISU_IR_02 / ISU_R_07).
         # SDI integration is indirect — DPR is responsible for SDI ingestion.
         if self.dpr_service:
-            dpr_result = self.dpr_service.process_in_situ(df, metadata)
+            with tempfile.NamedTemporaryFile(
+                suffix='.csv', delete=False, prefix=f'{dataset_id}_'
+            ) as tmp:
+                tmp_path = tmp.name
+            df.to_csv(tmp_path, index=False)
+            self.logger.debug(f'[ISU_I_1] Streaming data written to temporary file: {tmp_path}')
+            dpr_result = self.dpr_service.process_in_situ(tmp_path, metadata)
             self.logger.info(
                 f'[ISU_I_1] Stream data from {dataset_id} delivered to DPR: '
                 f'ready_for_sdi={dpr_result.get("ready_for_sdi")}'

--- a/subsystems/isu/etl_engine/pipeline.py
+++ b/subsystems/isu/etl_engine/pipeline.py
@@ -295,7 +295,9 @@ class ETLEngine(GaiaBase):
             ) as tmp:
                 tmp_path = tmp.name
             df.to_csv(tmp_path, index=False)
-            self.logger.debug(f'[ISU_I_1] Streaming data written to temporary file: {tmp_path}')
+            self.logger.debug(
+                f'[ISU_I_1] Streaming data written to temporary file: {tmp_path}'
+            )
             dpr_result = self.dpr_service.process_in_situ(tmp_path, metadata)
             self.logger.info(
                 f'[ISU_I_1] Stream data from {dataset_id} delivered to DPR: '

--- a/subsystems/isu/etl_engine/pipeline.py
+++ b/subsystems/isu/etl_engine/pipeline.py
@@ -142,8 +142,10 @@ class ETLEngine(GaiaBase):
             ext = filename.rsplit('.', 1)[-1].lower() if '.' in filename else 'unknown'
             parser_applied = result.get('parser_applied', '')
             parser_short = (
-                'slope' if 'slope' in parser_applied.lower()
-                else 'water' if 'water' in parser_applied.lower()
+                'slope'
+                if 'slope' in parser_applied.lower()
+                else 'water'
+                if 'water' in parser_applied.lower()
                 else parser_applied
             )
 

--- a/subsystems/isu/etl_engine/pipeline.py
+++ b/subsystems/isu/etl_engine/pipeline.py
@@ -5,6 +5,74 @@ from lib.base import GaiaBase, SubsystemId
 
 from .parsers import ParsingEngine
 
+# Keywords used to infer sensor type from filename
+_SENSOR_TYPE_FILENAME_KEYWORDS: Dict[str, list] = {
+    'piezometer': ['piezo', 'piezometer'],
+    'inclinometer': ['inclin', 'tilt'],
+    'gnss': ['gnss', 'gps'],
+    'insar': ['insar', 'sar', 'egms', 'ground_motion'],
+    'sonde': ['sonde', 'hydro'],
+    'water_quality': ['water', 'quality', 'wq'],
+}
+
+# Fallback: keywords matched against column names
+_SENSOR_TYPE_COLUMN_KEYWORDS: Dict[str, list] = {
+    'piezometer': ['pressure', 'kpa', 'pore_water', 'pore'],
+    'inclinometer': ['tilt', 'inclin', 'angle', 'deflection'],
+    'gnss': ['displacement', 'velocity', 'def_x', 'def_y', 'def_z'],
+    'insar': ['coherence', 'los', 'deformation'],
+    'sonde': ['ph', 'turbidity', 'conductivity', 'dissolved', 'orp'],
+    'water_quality': ['nitrate', 'sulfate', 'tds', 'mg/l'],
+}
+
+
+def _infer_sensor_type(filename: str, columns: Optional[list] = None) -> Optional[str]:
+    # Primary: filename keywords
+    name = filename.lower()
+    for sensor, keywords in _SENSOR_TYPE_FILENAME_KEYWORDS.items():
+        if any(kw in name for kw in keywords):
+            return sensor
+    # Fallback: column name keywords
+    if columns:
+        cols_str = ' '.join(c.lower() for c in columns)
+        for sensor, keywords in _SENSOR_TYPE_COLUMN_KEYWORDS.items():
+            if any(kw in cols_str for kw in keywords):
+                return sensor
+    return None
+
+
+def _extract_location(
+    df: pd.DataFrame,
+    filename: str = '',
+    settings: Optional[Dict] = None,
+) -> Optional[Dict[str, Any]]:
+    # Primary: lat/lon columns in the CSV
+    lat_col = next((c for c in df.columns if 'lat' in c.lower()), None)
+    lon_col = next((c for c in df.columns if 'lon' in c.lower()), None)
+    if lat_col and lon_col:
+        lats = pd.to_numeric(df[lat_col], errors='coerce').dropna()
+        lons = pd.to_numeric(df[lon_col], errors='coerce').dropna()
+        if not lats.empty and not lons.empty:
+            return {'bbox': [lons.min(), lats.min(), lons.max(), lats.max()]}
+    # Fallback: site coordinates from settings.yaml
+    if settings and filename:
+        sites = settings.get('isu', {}).get('sites', {})
+        name_lower = filename.lower()
+        for site_name, site_config in sites.items():
+            if site_name.lower() in name_lower:
+                bbox = site_config.get('bbox')
+                if bbox:
+                    return {'bbox': bbox, 'source': 'settings'}
+    return None
+
+
+def _extract_time_range(df: pd.DataFrame) -> Optional[Dict[str, str]]:
+    if 'iso_timestamp' in df.columns:
+        ts = pd.to_datetime(df['iso_timestamp'], errors='coerce').dropna()
+        if not ts.empty:
+            return {'start': ts.min().isoformat(), 'end': ts.max().isoformat()}
+    return None
+
 
 class ETLEngine(GaiaBase):
     """
@@ -44,7 +112,10 @@ class ETLEngine(GaiaBase):
         self.logger.info('ETL Engine initialized with ParsingEngine.')
 
     def process_file(
-        self, file_content: bytes, filename: str
+        self,
+        file_content: bytes,
+        filename: str,
+        ingestion_mode: str = 'manual',
     ) -> Optional[Dict[str, Any]]:
         """
         Interface 1: Dedicated for ManualFileLoader and BulkUploadScheduler.
@@ -54,6 +125,8 @@ class ETLEngine(GaiaBase):
         :type file_content: bytes
         :param filename: The original name of the file.
         :type filename: str
+        :param ingestion_mode: How the file was ingested ('manual' or 'bulk').
+        :type ingestion_mode: str
         :return: A standardized payload dictionary or None if quarantined/failed QC.
         :rtype: Optional[Dict[str, Any]]
         """
@@ -66,12 +139,31 @@ class ETLEngine(GaiaBase):
             # Extract the successfully parsed DataFrame
             df = result.get('data')
 
-            # Assemble data context metadata
+            ext = filename.rsplit('.', 1)[-1].lower() if '.' in filename else 'unknown'
+            parser_applied = result.get('parser_applied', '')
+            parser_short = (
+                'slope' if 'slope' in parser_applied.lower()
+                else 'water' if 'water' in parser_applied.lower()
+                else parser_applied
+            )
+
+            # Assemble structured metadata
             metadata = {
-                'source_file': filename,
-                'parser_applied': result.get('parser_applied'),
-                'confidence': result.get('confidence'),
-                'ingestion_mode': 'manual_or_bulk',
+                'ingestion': {
+                    'mode': ingestion_mode,
+                    'source': filename,
+                    'parser': parser_short,
+                    'confidence': result.get('confidence'),
+                },
+                'data': {
+                    'type': 'in_situ',
+                    'format': ext,
+                    'sensor_type': _infer_sensor_type(filename, list(df.columns)),
+                    'time_range': _extract_time_range(df),
+                    'schema': list(df.columns),
+                    'location': _extract_location(df, filename, self.settings),
+                    'crs': 'EPSG:4326',
+                },
             }
 
             # Architectural Compliance: Intercept data via the Quality Control (QC) Layer
@@ -166,8 +258,24 @@ class ETLEngine(GaiaBase):
         :type qc_result: Dict[str, Any]
         :return: None
         """
-        sensor_type = metadata.get('sensor_type', 'unknown')
         dataset_id = metadata.get('source_topic_or_stream', 'unknown_stream')
+
+        # Enrich streaming metadata with the same structured format
+        data_meta = metadata.setdefault('data', {})
+        data_meta.setdefault('type', 'in_situ')
+        data_meta.setdefault('format', 'stream')
+        data_meta.setdefault('schema', list(df.columns))
+        data_meta.setdefault('crs', 'EPSG:4326')
+        if 'time_range' not in data_meta:
+            data_meta['time_range'] = _extract_time_range(df)
+        if 'location' not in data_meta:
+            data_meta['location'] = _extract_location(df, dataset_id, self.settings)
+
+        ingestion_meta = metadata.setdefault('ingestion', {})
+        ingestion_meta.setdefault('mode', 'streaming')
+        ingestion_meta.setdefault('source', dataset_id)
+
+        sensor_type = data_meta.get('sensor_type', 'unknown')
 
         self.logger.info(
             f'ETL Engine received valid streaming payload from {sensor_type} ({dataset_id}).'

--- a/subsystems/isu/tests/test_interfaces.py
+++ b/subsystems/isu/tests/test_interfaces.py
@@ -44,7 +44,11 @@ class TestInterfaces:
         assert result['dpr_result']['ready_for_sdi'] is True
 
     def test_IF1_002(self):
-        """ISU_I_1: ETLEngine delivers streaming data to DPR via process_in_situ()."""
+        """ISU_I_1: ETLEngine delivers streaming data to DPR via process_in_situ().
+
+        Streaming data is written to a temporary CSV file before handoff,
+        so DPR receives a file path (str) rather than a DataFrame directly.
+        """
         mock_dpr = MagicMock()
         mock_dpr.process_in_situ.return_value = {
             'status': 'processed',
@@ -63,7 +67,11 @@ class TestInterfaces:
 
         engine.process_data(df, metadata, qc_result)
 
-        mock_dpr.process_in_situ.assert_called_once_with(df, metadata)
+        mock_dpr.process_in_situ.assert_called_once()
+        call_args = mock_dpr.process_in_situ.call_args
+        file_path_arg = call_args[0][0]
+        assert isinstance(file_path_arg, str)
+        assert file_path_arg.endswith('.csv')
 
     # ------------------------------------------------------------------
     # ISU_I_2 – QCL (QualityControlLogging)


### PR DESCRIPTION
## Summary
- Restructures the metadata dict passed from ISU to DPR into a nested  `ingestion` / `data` format, aligning with the ISU→DPR interface contract
- Adds `time_range`, `schema`, `location`, `crs`, `sensor_type`, `format`  fields to support DPR's STAC item generation for in-situ CSV data (Issue #200)
- Adds `ingestion_mode` parameter to `process_file()` to distinguish  `manual` vs `bulk` upload paths

## Key changes
- `_infer_sensor_type()`: infers sensor type from filename keywords,  with fallback to column name keywords
- `_extract_location()`: extracts bbox from lat/lon columns (fuzzy match),  with fallback to site coordinates in `settings.yaml`
- `_extract_time_range()`: extracts start/end from `iso_timestamp` column

## Settings fallback (optional)
If a CSV file has no lat/lon columns, add site coordinates:

    isu:
      sites:
        site_A:
          bbox: [14.412, 50.082, 14.440, 50.092]

## Related
- Issue #200 