### PR TITLE
DPR: Change Sentinel2CloudCoverPipeline to use configure method from base class

### DIFF
--- a/subsystems/dpr/base_pipeline.py
+++ b/subsystems/dpr/base_pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Mapping, Any, Dict
+    from typing import Any, Dict
 
 from abc import ABC, abstractmethod
 
@@ -10,22 +10,52 @@ from lib.base import GaiaBase, SubsystemId
 
 
 class BasePipeline(ABC, GaiaBase):
-    metadata = {'title': 'unknown', 'abstract': 'unknown'}
+    metadata = {'title': 'unknown', 'abstract': 'unknown', 'params': None}
 
     def __init__(self):
         GaiaBase.__init__(self, SubsystemId.DPR)
+        self._config = None
 
-    def configure(self, config: Mapping[str, Any]) -> None:
+    def configure(self, **kwargs) -> None:
         """Configure pipeline using structured config.
 
         param Mapping[str, Any]: pipeline configuration in YAML structure
         """
-        self._config = config
+        self._config = kwargs
+
+    def _check_config(self):
+        """Check pipeline configuration based on metadata['params']
+
+        Raise RuntimeError on failure
+        """
+        if (
+            self.metadata.get('params', None) is None
+            or self.metadata['params'] is None
+            or len(self.metadata['params'].keys()) < 1
+        ):
+            raise RuntimeError('Pipeline has no paramaters defined')
+
+        if self._config is None:
+            raise RuntimeError('Pipeline is not configured. Call configure() method')
+
+        for k, v in self.metadata['params'].items():
+            if self._config.get(k, None) is None:
+                if v.get('default', None) is not None:
+                    self._config[k] = v['default']
+                else:
+                    raise RuntimeError(f"Parameter '{k}' not defined")
+            if type(self._config[k]) is not v['dtype']:
+                raise RuntimeError(f"Paramater '{k}' type mismatch")
 
     @abstractmethod
-    def run(self) -> None:
+    def _run(self) -> None:
         """Execute pipeline."""
         pass
+
+    def run(self) -> None:
+        """Execute pipeline."""
+        self._check_config()
+        return self._run()
 
 
 class PipelineFactory(GaiaBase):

--- a/subsystems/dpr/data_analysis_pipelines/water_masking.py
+++ b/subsystems/dpr/data_analysis_pipelines/water_masking.py
@@ -5,8 +5,9 @@ class Sentinel2WaterMaskingPipeline(DataAnalysisBasePipeline):
     metadata = {
         'title': 'Sentinel-2 Water Masking',
         'abstract': 'TBD',
+        'params': {},
     }
 
-    def run():
+    def _run():
         """To be implemented."""
         pass

--- a/subsystems/dpr/preprocessing_pipelines/cloudcover.py
+++ b/subsystems/dpr/preprocessing_pipelines/cloudcover.py
@@ -10,23 +10,31 @@ class Sentinel2CloudCoverPipeline(PreprocessingBasePipeline):
         'title': 'Sentinel-2 Cloud Cover',
         'abstract': 'Read metadata JSON file, retrieve Sentinel-2 scene path, compute cloud cover and other land cover'
         'classes from the SCL band, write the percentages to the metadata file.',
+        'params': {
+            'metadata_path': {
+                'dtype': str,
+                'description': 'Path to the JSON file containing the path key.',
+            },
+            'path_key': {
+                'dtype': str,
+                'description': 'Name of the metadata dictionary key containing the path to the raster.',
+            },
+            'scl_band': {
+                'dtype': int,
+                'description': 'The index of the Sentinel-2 SCL band (default is band 13).',
+                'default': 13,
+            },
+        },
     }
-
-    def __init__(self):
-        """Initialise with None values."""
-        self.raster_path = None
-        self.metadata_path = None
-        self.path_key = None
-        self.scl_band = None
 
     def _load_json(self):
         """Loads the JSON metadata file."""
-        with open(self.metadata_path, 'r') as f:
+        with open(self._config['metadata_path'], 'r') as f:
             return json.load(f)
 
     def _save_json(self):
         """Saves the current state of metadata back to the JSON file."""
-        with open(self.metadata_path, 'w') as f:
+        with open(self._config['metadata_path'], 'w') as f:
             json.dump(self.metadata, f, indent=4)
 
     def _get_path(self, metadata, key):
@@ -42,27 +50,32 @@ class Sentinel2CloudCoverPipeline(PreprocessingBasePipeline):
                     return result
         return None
 
-    def _process_scl_statistics(self):
+    def _process_scl_statistics(self, raster_path):
         """
         Extracts the SCL band, calculates pixel counts for each class,
         and appends the results to the JSON file.
+
+        :param str raster_path: path to raster file to be processed
         """
         # Register all GDAL drivers
         gdal.AllRegister()
-        dataset = gdal.Open(self.raster_path, gdal.GA_ReadOnly)
+        dataset = gdal.Open(raster_path, gdal.GA_ReadOnly)
 
         if dataset is None:
             raise Exception(
-                f'Unable to open {self.raster_path}. Ensure it is a valid raster.'
+                f'Unable to open {raster_path}. Ensure it is a valid raster.'
             )
 
-        if self.scl_band > dataset.RasterCount or self.scl_band < 1:
+        if (
+            self._config['scl_band'] > dataset.RasterCount
+            or self._config['scl_band'] < 1
+        ):
             raise ValueError(
-                f'Invalid band index {self.scl_band}. File has {dataset.RasterCount} bands.'
+                f'Invalid band index {self._config["scl_band"]}. File has {dataset.RasterCount} bands.'
             )
 
         # get slc band as array
-        band = dataset.GetRasterBand(self.scl_band)
+        band = dataset.GetRasterBand(self._config['scl_band'])
         band_data = band.ReadAsArray()
 
         if np.nanmax(band_data) > 12 or np.nanmax(band_data) < 0:
@@ -117,39 +130,31 @@ class Sentinel2CloudCoverPipeline(PreprocessingBasePipeline):
         # Save the updated metadata back to the file
         self._save_json()
 
-    def run(self, metadata_path: str = None, path_key: str = None, scl_band: int = 13):
-        """
-        :param metadata_path: Path to the JSON file containing the 'path' key.
-        :param path_key: Name of the metadata dictionary key containing the path to the raster.
-        :param scl_band: The index of the Sentinel-2 SCL band (default is band 13).
-        """
-        self.metadata_path = metadata_path
-
-        if not os.path.exists(self.metadata_path):
-            raise FileNotFoundError(f'Metadata file not found at: {self.metadata_path}')
-
-        self.path_key = path_key
-
-        if self.path_key is None:
-            raise KeyError("The 'path' key could not be found.")
-
-        self.scl_band = scl_band
-
-        if self.scl_band < 0:
-            raise ValueError(
-                f'Invalid SCL band index value {self.scl_band}. SCL band index should be greater than 0.'
+    def _run(self):
+        """ """
+        if not os.path.exists(self._config['metadata_path']):
+            raise FileNotFoundError(
+                f'Metadata file not found at: {self._config["metadata_path"]}'
             )
 
-        if not isinstance(self.scl_band, int):
+        if self._config['path_key'] is None:
+            raise KeyError("The 'path' key could not be found.")
+
+        if self._config['scl_band'] < 0:
+            raise ValueError(
+                f'Invalid SCL band index value {self._config["scl_band"]}. SCL band index should be greater than 0.'
+            )
+
+        if not isinstance(self._config['scl_band'], int):
             # Raise a ValueError with a descriptive message
             raise ValueError(
-                f'Invalid SCL band index value {self.scl_band}. Input value must be an integer.'
+                f'Invalid SCL band index value {self._config["scl_band"]}. Input value must be an integer.'
             )
 
         self.metadata = self._load_json()
-        self.raster_path = self._get_path(self.metadata, self.path_key)
+        raster_path = self._get_path(self.metadata, self._config['path_key'])
 
-        if not os.path.exists(self.raster_path):
-            raise FileNotFoundError(f'Raster file not found at: {self.raster_path}')
+        if not os.path.exists(raster_path):
+            raise FileNotFoundError(f'Raster file not found at: {raster_path}')
 
-        self._process_scl_statistics()
+        self._process_scl_statistics(raster_path)

--- a/subsystems/dpr/preprocessing_pipelines/sentinel1.py
+++ b/subsystems/dpr/preprocessing_pipelines/sentinel1.py
@@ -5,6 +5,7 @@ class Sentinel1Pipeline(PreprocessingBasePipeline):
     metadata = {
         'title': 'Sentinel-1',
         'abstract': 'Anomaly detection for slope stability: preprocess Sentinel-1 data',
+        'params': {},
     }
 
     def _build_sbas_stack(self):
@@ -13,7 +14,7 @@ class Sentinel1Pipeline(PreprocessingBasePipeline):
     def _reframe_sbas(self):
         raise NotImplementedError()
 
-    def run(self):
+    def _run(self):
         self._build_sbas_stack()
         self._reframe_sbas
         # ...

--- a/subsystems/dpr/tests/test_modules.py
+++ b/subsystems/dpr/tests/test_modules.py
@@ -20,13 +20,17 @@ class TestModules:
             and isinstance(v, dict)
             and isinstance(v.get('title'), str)
             and isinstance(v.get('abstract'), str)
+            and isinstance(v.get('params'), dict)
             for k, v in data.items()
-        ), "Invalid structure: expected {str: {'title': str, 'abstract': str}}"
+        ), (
+            "Invalid structure: expected {str: {'title': str, 'abstract': str, 'params': dict}}"
+        )
 
         assert len(module.pipelines) > 0
         for name, pipeline in module.pipelines.items():
             assert isinstance(name, str)
             assert isinstance(pipeline.metadata['title'], str)
+            assert isinstance(pipeline.metadata['params'], dict)
 
     def test_DataAnalysisPipelines_001(self):
         """Test PreprocessingPipelines module.
@@ -40,13 +44,17 @@ class TestModules:
             and isinstance(v, dict)
             and isinstance(v.get('title'), str)
             and isinstance(v.get('abstract'), str)
+            and isinstance(v.get('params'), dict)
             for k, v in data.items()
-        ), "Invalid structure: expected {str: {'title': str, 'abstract': str}}"
+        ), (
+            "Invalid structure: expected {str: {'title': str, 'abstract': str, 'param': dict}}"
+        )
 
         assert len(module.pipelines) > 0
         for name, pipeline in module.pipelines.items():
             assert isinstance(name, str)
             assert isinstance(pipeline.metadata['title'], str)
+            assert isinstance(pipeline.metadata['params'], dict)
 
     def test_DataAnalysisPipelines_002(self):
         """Test DataAnalysisPipelines module.

--- a/subsystems/dpr/tests/test_sentinel2.py
+++ b/subsystems/dpr/tests/test_sentinel2.py
@@ -39,7 +39,8 @@ class TestSentinel2Workflow:
 
         # Run the pipeline
         pipeline = Sentinel2CloudCoverPipeline()
-        pipeline.run(metadata_path=metadata_path, path_key='source_path', scl_band=13)
+        pipeline.configure(metadata_path=metadata_path, path_key='source_path')
+        pipeline.run()
 
         # Verification of the outputs
         # get the processed metadata file:


### PR DESCRIPTION
This PR changes `Sentinel2CloudCoverPipeline` to use `configure()` method from base class. 

Pipeline arguments are not passed by `run()` method but newly by `configure()`:

Was:

```py
        pipeline = Sentinel2CloudCoverPipeline()                                                                          
        pipeline.run(metadata_path=metadata_path, path_key='source_path')                                           
```

Changed to:

```py
        pipeline = Sentinel2CloudCoverPipeline()                                                                          
        pipeline.configure(metadata_path=metadata_path, path_key='source_path')                                           
        pipeline.run()       
```

The parameters are defined by pipeline metadata:

```
        'params': {                                                                                                       
            'metadata_path': {                                                                                            
                'dtype': str,                                                                                             
                'description': 'Path to the JSON file containing the path key.',                                          
            },                                                                                                            
            'path_key': {                                                                                                 
                'dtype': str,                                                                                             
                'description': 'Name of the metadata dictionary key containing the path to the raster.',                  
            },                                                                                                            
            'scl_band': {                                                                                                 
                'dtype': int,                                                                                             
                'description': 'The index of the Sentinel-2 SCL band (default is band 13).',                              
                'default': 13,                                                                                            
            },                                                                                                            
        },   
```

There is `_check_config()` method which is performed on runtime to check whether all parameters were defined.