### PR TITLE
test_insitu_metadata: Stub out osgeo so generator.py

### DIFF
--- a/subsystems/dpr/tests/test_insitu_metadata.py
+++ b/subsystems/dpr/tests/test_insitu_metadata.py
@@ -13,17 +13,6 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
-# Stub out osgeo so generator.py can be imported without GDAL installed
-for _mod in ('osgeo', 'osgeo.gdal', 'osgeo.osr'):
-    sys.modules.setdefault(_mod, types.ModuleType(_mod))
-_gdal = sys.modules['osgeo.gdal']
-if not hasattr(_gdal, 'UseExceptions'):
-    _gdal.UseExceptions = lambda: None  # type: ignore[attr-defined]
-
-_sqlalchemy = types.ModuleType('sqlalchemy')
-_sqlalchemy.create_engine = MagicMock()  # type: ignore[attr-defined]
-sys.modules.setdefault('sqlalchemy', _sqlalchemy)
-
 from subsystems.dpr.metadata_processor.generator import (
     InsituDataset,
     InsituStacItemFactory,

--- a/subsystems/dpr/tests/test_insitu_metadata.py
+++ b/subsystems/dpr/tests/test_insitu_metadata.py
@@ -5,9 +5,7 @@ Covers InsituDataset, InsituStacItemFactory, and MetadataGenerator for CSV datas
 """
 
 import os
-import sys
 import tempfile
-import types
 from unittest.mock import MagicMock
 
 import pandas as pd


### PR DESCRIPTION
This hack causes test failures in #218: https://github.com/GAIA-TSF/GAIA-TSF-System/actions/runs/25174507185/job/73908613673?pr=218

I would suggest to remove it.