### PR TITLE
ISU: add default QC column in parsers and office record metadata support

### DIFF
--- a/subsystems/isu/etl_engine/parsers/base.py
+++ b/subsystems/isu/etl_engine/parsers/base.py
@@ -47,6 +47,14 @@ class BaseParser(ABC):
         """Parse content into structured dictionary."""
         pass
 
+    def ensure_qc_column(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Add default QC=1 column if absent. QC=1 means valid sensor data."""
+        if not any(c.upper() == 'QC' for c in df.columns):
+            df = df.copy()
+            df['QC'] = 1
+            self.logger.debug(f'[{self.get_parser_name()}] Added default QC=1 column.')
+        return df
+
     def standardize_timestamp(
         self,
         df: pd.DataFrame,

--- a/subsystems/isu/etl_engine/parsers/slope.py
+++ b/subsystems/isu/etl_engine/parsers/slope.py
@@ -90,6 +90,7 @@ class SlopeStabilityParser(BaseParser):
             df = self.standardize_timestamp(
                 df, ['timestamp', 'date', 'time', 'reading_time', 'epoch']
             )
+            df = self.ensure_qc_column(df)
 
             # Return cleaned DataFrame
             return df

--- a/subsystems/isu/etl_engine/parsers/water.py
+++ b/subsystems/isu/etl_engine/parsers/water.py
@@ -83,6 +83,7 @@ class WaterQualityParser(BaseParser):
             # 2. Standardize Timestamp
             #
             df = self.standardize_timestamp(df)
+            df = self.ensure_qc_column(df)
 
             return df
 

--- a/subsystems/isu/etl_engine/pipeline.py
+++ b/subsystems/isu/etl_engine/pipeline.py
@@ -151,6 +151,8 @@ class ETLEngine(GaiaBase):
             )
 
             # Assemble structured metadata
+            # TODO: set data_source='office_interpreted' for manually created records
+            # once the UI/API layer can pass this information to process_file().
             metadata = {
                 'ingestion': {
                     'mode': ingestion_mode,
@@ -277,6 +279,7 @@ class ETLEngine(GaiaBase):
         ingestion_meta = metadata.setdefault('ingestion', {})
         ingestion_meta.setdefault('mode', 'streaming')
         ingestion_meta.setdefault('source', dataset_id)
+        ingestion_meta.setdefault('data_source', 'sensor')
 
         sensor_type = data_meta.get('sensor_type', 'unknown')
 


### PR DESCRIPTION
Summary:
Implements ISU-side changes required by the QCL office record detection feature (#263).

Changes
parsers/base.py: Added ensure_qc_column(), appends a default QC=1 column when the parsed CSV does not already contain one. Ensures QCL's QC+PLATFORM fallback detection works correctly for datasets without an explicit QC flag.
parsers/water.py, parsers/slope.py: Call ensure_qc_column() at the end of parse().
pipeline.py: Streaming path now sets ingestion.data_source = 'sensor' explicitly, aligning with QCL's primary detection path.

Pending
ingestion.data_source = 'office_interpreted' for manually uploaded office-interpreted records requires the UI to pass this flag to process_file(). A TODO comment has been added at the relevant location.