### PR TITLE
Add config.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ __marimo__/
 # Additional
 *~
 .idea/
+config.yaml


### PR DESCRIPTION
Add config.yaml to .gitignore to prevent EODAG/ASF credentials from being committed to the Git repository.