### PR TITLE
Exec gaiatesting a non-root user

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
           for i in $(ls subsystems/ale/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -53,7 +53,7 @@ jobs:
           for i in $(ls subsystems/dag/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -78,7 +78,7 @@ jobs:
           for i in $(ls subsystems/dpr/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -vv $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -vv $i
             cd ..
           done
 
@@ -103,7 +103,7 @@ jobs:
           for i in $(ls subsystems/eou/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -123,7 +123,7 @@ jobs:
           for i in $(ls subsystems/isu/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -143,7 +143,7 @@ jobs:
           for i in $(ls subsystems/map/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -163,7 +163,7 @@ jobs:
           for i in $(ls subsystems/ntf/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -183,7 +183,7 @@ jobs:
           for i in $(ls subsystems/qcl/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -203,7 +203,7 @@ jobs:
           for i in $(ls subsystems/rep/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -223,7 +223,7 @@ jobs:
           for i in $(ls subsystems/sdi/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -243,7 +243,7 @@ jobs:
           for i in $(ls subsystems/vid/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done
 
@@ -263,6 +263,6 @@ jobs:
           for i in $(ls tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
             cd ..
           done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,13 +88,13 @@ docker compose up --build
 Run tests for the testfile wished:
 
 ```sh
-docker exec gaiatesting python3 -m pytest /opt/gaia_tsf/subsystems/subsystem/tests/testfile.py -v
+docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest subsystems/subsystem/tests/testfile.py -v
 ```
 
 For executing long-running tests (which are excluded from CI), use the slow pytest marker.
 
 ```sh
-docker exec gaiatesting python3 -m pytest -m slow /opt/gaia_tsf/subsystems/subsystem/tests/testfile.py -v
+docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -m slow subsystems/subsystem/tests/testfile.py -v
 ```
 
 ### Virtual environment

--- a/subsystems/dag/README.md
+++ b/subsystems/dag/README.md
@@ -75,9 +75,3 @@ python3 -m pytest subsystems/dag/tests/test_amd_pipeline.py
 python3 -m pytest subsystems/dag/tests/test_slope_pipeline.py  
 
 ```
-
-```
-cd docker
-docker compose up --build
-docker exec gaiatesting python3 -m pytest /opt/gaia_tsf/subsystems/dag/tests -v
-```

--- a/subsystems/isu/README.md
+++ b/subsystems/isu/README.md
@@ -81,10 +81,3 @@ isu:
   ogc_broker: "mqtt.example.org:1883"
   ogc_datastream_id: "99"
 ```
-
-
-To run the tests, execute the following command in your terminal:
-
-```bash
-docker exec gaiatesting python3 -m pytest subsystems/isu/tests/ -v -p no:cacheprovider --basetemp=test_tmp
-```


### PR DESCRIPTION
It’s recommended to run gaiatesting as a non-root user, since the data volume is now mounted as persistent storage (see #310)

Currently:

```
cd ../docker
$ docker compose exec gaiatesting touch /data/gaia_tsf/x
$ ls -lh ../tests/data/x
-rw-r--r-- 1 root root 0 May 19 12:06 ../tests/data/x
```

Recommended:

```
$ docker compose exec -u $(id -u):$(id -g) gaiatesting $ touch /data/gaia_tsf/x
$ ls -lh ../tests/data/x
-rw-r--r-- 1 landamar landamar 0 May 19 12:08 ../tests/data/x
```

