### PR TITLE
project.aoi() returns shapely geometry

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
     paths:
-      - 'lib/**'
       - 'subsystems/**'
       - 'docker/**'
       - '.github/workflows/pytest.yml'
@@ -13,7 +12,6 @@ on:
       - "!**.md"
   pull_request:
     paths:
-      - 'lib/**'
       - 'subsystems/**'
       - 'docker/**'
       - '.github/workflows/pytest.yml'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - develop
     paths:
+      - 'lib/**'
       - 'subsystems/**'
       - 'docker/**'
       - '.github/workflows/pytest.yml'
       - "!**.md"
   pull_request:
     paths:
+      - 'lib/**'
       - 'subsystems/**'
       - 'docker/**'
       - '.github/workflows/pytest.yml'

--- a/lib/config.py
+++ b/lib/config.py
@@ -145,15 +145,6 @@ class ProjectConfigReader(ConfigReader, YamlValidator):
 
         self.validate(dict(self))
 
-    def aoi_geom(self, aoi: str) -> BaseGeometry:
-        """Get area of interest as shapely geometry.
-
-        :param str aoi: WKT string provided by aoi()
-
-        :return: BaseGeometry
-        """
-        return wkt.loads(aoi)
-
     def aoi(self, target_epsg: int = 4326) -> BaseGeometry:
         """Get area of interest as WKT string in specified CRS.
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from shapely import wkt
 from shapely.errors import ShapelyError
+from shapely.geometry.base import BaseGeometry
 from osgeo import gdal, osr
 
 gdal.UseExceptions()
@@ -101,20 +102,19 @@ class YamlValidator:
                 if Path(self.config_path.parent / value).exists() is False:
                     errors.append(f"AOI '{current_path}' not found.")
                 else:
-                    if self._is_valid_wkt(self.aoi()) is False:
+                    if self._is_valid_geom(self.aoi()) is False:
                         errors.append(f"Geometry in '{current_path}' is not valid.")
 
     @staticmethod
-    def _is_valid_wkt(wkt_string: str) -> bool:
+    def _is_valid_geom(geom: BaseGeometry) -> bool:
         """Check WKT by shapely if it's valid.
 
-        :param str wkt_string: WKT to be validated
+        :param BaseGeometry geom: geometry to be validated
 
         :return: validity flag (True/False)
         :rtype: bool
         """
         try:
-            geom = wkt.loads(wkt_string)
             return geom.is_valid
         except (ShapelyError, TypeError):
             return False
@@ -145,13 +145,22 @@ class ProjectConfigReader(ConfigReader, YamlValidator):
 
         self.validate(dict(self))
 
-    def aoi(self, target_epsg: int = 4326):
+    def aoi_geom(self, aoi: str) -> BaseGeometry:
+        """Get area of interest as shapely geometry.
+
+        :param str aoi: WKT string provided by aoi()
+
+        :return: BaseGeometry
+        """
+        return wkt.loads(aoi)
+
+    def aoi(self, target_epsg: int = 4326) -> BaseGeometry:
         """Get area of interest as WKT string in specified CRS.
 
         :param int epsg: EPSG code for target CRS
 
-        :return WKT string
-        :rtype str
+        :return: Shapely geometry
+        :rtype BaseGeometry
         """
         file_path = self.config_path.parent / self['project']['aoi']
         ds = gdal.OpenEx(file_path, gdal.OF_VECTOR)
@@ -179,10 +188,11 @@ class ProjectConfigReader(ConfigReader, YamlValidator):
         if transform is not None:
             geom.Transform(transform)
 
-        wkt = geom.ExportToWkt()
+        aoi_geom = wkt.loads(geom.ExportToWkt())
+
         ds = None
 
-        return wkt
+        return aoi_geom
 
 
 class SettingsReader(ConfigReader):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,3 +35,7 @@ class TestConfig:
         config['project']['aoi'] = 'X'
         config.validate(dict(config))  # re-validate config after modification
         assert config.is_valid() is False
+
+    def test_config_003_aoi_geom(self, project_config):
+        """Test AOI definitions provided by ProjectConfigReader."""
+        assert project_config.aoi().wkt.startswith('POLYGON')


### PR DESCRIPTION
This PR changes `ProjectConfigReader.aoi()`  to return shapely geometry instead of WKT.

Reason: Sentinel-1 workflow based on ASF requires shapely geometry. 

WKT may be retrieved from geometry by `.wkt` property.