### PR TITLE
.gitignore: add .swp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ __marimo__/
 config.yaml
 tests/data/*
 venv/
+*.swp


### PR DESCRIPTION
used for swapped memory, e.g. by vim