### PR TITLE
Mark test_MetadataGenerator_003/004 as slow

### DIFF
--- a/subsystems/dpr/tests/test_modules.py
+++ b/subsystems/dpr/tests/test_modules.py
@@ -1,7 +1,7 @@
 import json
 import os
 import zipfile
-
+import pytest
 from pathlib import Path
 
 from lib.config import ProjectConfigReader
@@ -149,6 +149,7 @@ class TestModules:
             json.loads(json.dumps(item_dict))
         ) == item_dict_no_datetime(json_dict)
 
+    @pytest.mark.slow
     def test_MetadataGenerator_003(self, tmp_path):
         """Test MetadataGenerator module.
 
@@ -166,6 +167,7 @@ class TestModules:
             json.loads(json.dumps(item_dict))
         ) == item_dict_no_datetime(json_dict)
 
+    @pytest.mark.slow
     def test_MetadataGenerator_004(self, tmp_path):
         """Test MetadataGenerator module.
 

--- a/subsystems/dpr/tests/test_modules.py
+++ b/subsystems/dpr/tests/test_modules.py
@@ -132,6 +132,7 @@ class TestModules:
             json_dict = json.load(f)
         assert item_dict_no_datetime(item_dict) == item_dict_no_datetime(json_dict)
 
+    @pytest.mark.slow
     def test_MetadataGenerator_002(self, tmp_path):
         """Test MetadataGenerator module.
 


### PR DESCRIPTION
This PR temporarily marks the `test_MetadataGenerator_002-004` tests as slow, excluding them from the CI workflow. These tests can take more than 40 minutes to complete and may still fail due to their dependency on downloading full scenes from CDSE, see eg. https://github.com/GAIA-TSF/GAIA-TSF-System/actions/runs/26883789515/job/79290386993?pr=369

A longer-term solution is needed. The tests should be refactored to use a small set of pre-downloaded reference scenes that are readily accessible in CI, rather than fetching data from CDSE during test execution. GitHub Large File Storage (LFS) or another artifact storage solution could be considered for this purpose.