### PR TITLE
Introduce GAIA_EOU_AUTH_CREDENTIALS_PASSWORD env. variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,12 @@ Release Management
 
 ### Testing
 
+Note: The password is required for downloading Earth Observation (EO)
+data through EODAG or ASF. If the `docker/.env` file contains the
+`GAIA_EOU_AUTH_CREDENTIALS_PASSWORD` environment variable, there is no
+need to specify the password in `config.yaml`, as it will be read from
+the environment automatically.
+
 Build docker:
 
 ```sh

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ eou:
       auth:
         credentials: &cred
           username: 'gaia.tsf.project@gmail.com'
-          password: ''
+          password: '' # may be defined also by GAIA_EOU_AUTH_CREDENTIALS_PASSWORD env. variable
   asf:
     auth:
       credentials:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     environment:
       # timezonefinder uses Numba JIT caching - this often breaks in Docker/CI environments
       NUMBA_DISABLE_JIT: 1
+      # may be defined by .env
+      GAIA_EOU_AUTH_CREDENTIALS_PASSWORD: ${GAIA_EOU_AUTH_CREDENTIALS_PASSWORD:-}
 
   postgis:
     image: postgis/postgis:16-3.4

--- a/subsystems/eou/data_acquisition_gateway/base_backend.py
+++ b/subsystems/eou/data_acquisition_gateway/base_backend.py
@@ -11,6 +11,14 @@ class DataAcquisitionBackend(ABC):
     def set_config(self, config: dict) -> None:
         self.config = config
 
+        # check password
+        if 'cop_dataspace' in self.config: # eodag
+            credentials = self.config['cop_dataspace']['auth']['credentials']
+        else:
+            credentials = self.config['auth']['credentials']
+        if not credentials['password'] and os.environ.get('GAIA_EOU_AUTH_CREDENTIALS_PASSWORD'):
+            credentials['password'] = os.environ['GAIA_EOU_AUTH_CREDENTIALS_PASSWORD']
+
     @abstractmethod
     def search(self, *args, **kwargs):
         """Generic search interface"""

--- a/subsystems/eou/data_acquisition_gateway/base_backend.py
+++ b/subsystems/eou/data_acquisition_gateway/base_backend.py
@@ -12,11 +12,13 @@ class DataAcquisitionBackend(ABC):
         self.config = config
 
         # check password
-        if 'cop_dataspace' in self.config: # eodag
+        if 'cop_dataspace' in self.config:  # eodag
             credentials = self.config['cop_dataspace']['auth']['credentials']
         else:
             credentials = self.config['auth']['credentials']
-        if not credentials['password'] and os.environ.get('GAIA_EOU_AUTH_CREDENTIALS_PASSWORD'):
+        if not credentials['password'] and os.environ.get(
+            'GAIA_EOU_AUTH_CREDENTIALS_PASSWORD'
+        ):
             credentials['password'] = os.environ['GAIA_EOU_AUTH_CREDENTIALS_PASSWORD']
 
     @abstractmethod


### PR DESCRIPTION
This PR adds support for defining the password required to download EO data via EODAG or ASF through the `GAIA_EOU_AUTH_CREDENTIALS_PASSWORD` environment variable. The variable can be specified in `docker/.env`.
Benefits:

- No modifications to `config.yaml` are required, reducing the risk of accidentally committing credentials.
- Simplifies the handling of GitHub Secrets in CI. Removes the need for `.github/utils/update_config.py` to inject the password into the configuration. (this can be done once this PR is merged)


