### PR TITLE
EOU: DataExtraction module moved to DPR

### DIFF
--- a/subsystems/eou/tests/test_modules.py
+++ b/subsystems/eou/tests/test_modules.py
@@ -203,10 +203,3 @@ class TestModules:
         finally:
             if datadir.exists() and datadir.is_dir():
                 shutil.rmtree(datadir)
-
-    def test_DataExtraction_001(self):
-        """Test DataExtraction module.
-
-        Example of unit test.
-        """
-        pass


### PR DESCRIPTION
This PR remove empty test for `DataExtraction` module.