### PR TITLE
docker: update eodag to 4.4

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -3,7 +3,7 @@ boto3~=1.42.60  # eou
 gdal==3.10.3  # eou, dpr
 requests~=2.32.5  # eou, sdi
 psycopg~=3.2.13  # sdi
-eodag~=3.10.1  # eou
+eodag~=4.4.0  # eou
 pandas~=3.0.1  # isu
 openpyxl~=3.1.5  # isu
 pyyaml~=6.0.3  # lib.config, eou


### PR DESCRIPTION
Required by #397 