### PR TITLE
ISU: add in-situ support in MetadataValidator

### DIFF
--- a/subsystems/dpr/metadata_processor/schemas/insitu.json
+++ b/subsystems/dpr/metadata_processor/schemas/insitu.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gaia-tsf.github.io/stac-extensions/insitu/v1.0.0/schema.json",
+  "title": "GAIA In-Situ Extension",
+  "description": "Custom validation rules for in-situ CSV-based STAC Items in GAIA-TSF.",
+  "type": "object",
+  "properties": {
+    "properties": {
+      "type": "object",
+      "required": ["start_datetime", "end_datetime"],
+      "properties": {
+        "start_datetime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end_datetime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "assets": {
+      "type": "object",
+      "required": ["data"],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": ["table:columns"],
+          "properties": {
+            "table:columns": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/subsystems/dpr/metadata_processor/validator.py
+++ b/subsystems/dpr/metadata_processor/validator.py
@@ -7,9 +7,14 @@ if TYPE_CHECKING:
 import pystac
 import requests
 import json
+import jsonschema
+from datetime import datetime
+from pathlib import Path
 
 from lib.base import GaiaBase, SubsystemId
 from lib.config import SettingsReader
+
+_INSITU_SCHEMA_PATH = Path(__file__).parent / 'schemas' / 'insitu.json'
 
 
 class MetadataValidator(GaiaBase):
@@ -20,6 +25,52 @@ class MetadataValidator(GaiaBase):
     def __init__(self):
         """Initialize metadata validator."""
         super().__init__(SubsystemId.DPR)
+
+    @staticmethod
+    def _is_insitu(item: pystac.Item) -> bool:
+        data_asset = item.assets.get('data')
+        return item.collection_id == 'insitu' or (
+            data_asset is not None and data_asset.media_type == 'text/csv'
+        )
+
+    def _validate_insitu(self, item: pystac.Item, result: dict) -> None:
+        with open(_INSITU_SCHEMA_PATH) as f:
+            schema = json.load(f)
+
+        try:
+            jsonschema.validate(instance=item.to_dict(), schema=schema)
+        except jsonschema.ValidationError as e:
+            result['valid'] = False
+            result['errors'].append(f"In-situ schema validation failed: {e.message}")
+
+        # start < end cannot be expressed in JSON Schema
+        props = item.properties
+        start = props.get('start_datetime')
+        end = props.get('end_datetime')
+        if start and end:
+            try:
+                if datetime.fromisoformat(start) >= datetime.fromisoformat(end):
+                    result['valid'] = False
+                    result['errors'].append(
+                        f"'start_datetime' must be before 'end_datetime' "
+                        f"(got {start} >= {end})."
+                    )
+            except ValueError as e:
+                result['valid'] = False
+                result['errors'].append(f"Invalid datetime format in time range: {e}")
+
+        # bbox range check cannot be expressed in JSON Schema
+        if item.bbox:
+            min_lon, min_lat, max_lon, max_lat = item.bbox
+            if not (
+                -180 <= min_lon <= max_lon <= 180
+                and -90 <= min_lat <= max_lat <= 90
+            ):
+                result['valid'] = False
+                result['errors'].append(
+                    f"bbox {item.bbox} is outside valid WGS-84 bounds "
+                    f"(lon: -180..180, lat: -90..90)."
+                )
 
     def validate(self, metadata_path: Path):
         """
@@ -72,6 +123,9 @@ class MetadataValidator(GaiaBase):
 
             # read input metadata file
             obj = pystac.read_file(metadata_path)
+
+            if self._is_insitu(obj):
+                self._validate_insitu(obj, result)
 
             # if it's an Item, create a Catalog to hold it
             catalog = pystac.Catalog(

--- a/subsystems/dpr/metadata_processor/validator.py
+++ b/subsystems/dpr/metadata_processor/validator.py
@@ -41,7 +41,7 @@ class MetadataValidator(GaiaBase):
             jsonschema.validate(instance=item.to_dict(), schema=schema)
         except jsonschema.ValidationError as e:
             result['valid'] = False
-            result['errors'].append(f"In-situ schema validation failed: {e.message}")
+            result['errors'].append(f'In-situ schema validation failed: {e.message}')
 
         # start < end cannot be expressed in JSON Schema
         props = item.properties
@@ -53,23 +53,22 @@ class MetadataValidator(GaiaBase):
                     result['valid'] = False
                     result['errors'].append(
                         f"'start_datetime' must be before 'end_datetime' "
-                        f"(got {start} >= {end})."
+                        f'(got {start} >= {end}).'
                     )
             except ValueError as e:
                 result['valid'] = False
-                result['errors'].append(f"Invalid datetime format in time range: {e}")
+                result['errors'].append(f'Invalid datetime format in time range: {e}')
 
         # bbox range check cannot be expressed in JSON Schema
         if item.bbox:
             min_lon, min_lat, max_lon, max_lat = item.bbox
             if not (
-                -180 <= min_lon <= max_lon <= 180
-                and -90 <= min_lat <= max_lat <= 90
+                -180 <= min_lon <= max_lon <= 180 and -90 <= min_lat <= max_lat <= 90
             ):
                 result['valid'] = False
                 result['errors'].append(
-                    f"bbox {item.bbox} is outside valid WGS-84 bounds "
-                    f"(lon: -180..180, lat: -90..90)."
+                    f'bbox {item.bbox} is outside valid WGS-84 bounds '
+                    f'(lon: -180..180, lat: -90..90).'
                 )
 
     def validate(self, metadata_path: Path):

--- a/subsystems/dpr/tests/test_modules.py
+++ b/subsystems/dpr/tests/test_modules.py
@@ -1,15 +1,81 @@
 import json
+import os
 import pytest
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from lib.config import ProjectConfigReader
 from subsystems.eou.data_acquisition_gateway import DataAcquisitionGateway
 from subsystems.dpr.metadata_processor import MetadataGenerator
 from subsystems.dpr.metadata_processor import MetadataValidator
+from subsystems.dpr.metadata_processor.generator import InsituDataset, StacItemFactory
 from subsystems.dpr.preprocessing_pipelines import PreprocessingPipelines
 from subsystems.dpr.data_analysis_pipelines import DataAnalysisPipelines
 from tests.utils import TestUtils
+
+
+_INSITU_META = {
+    'ingestion': {'mode': 'manual', 'source': 'sensor.csv'},
+    'data': {
+        'type': 'in_situ',
+        'format': 'csv',
+        'sensor_type': 'piezometer',
+        'time_range': {
+            'start': '2026-01-01T00:00:00Z',
+            'end': '2026-06-30T23:59:59Z',
+        },
+        'schema': ['iso_timestamp', 'lat', 'lon', 'pressure'],
+        'location': {'bbox': [14.412, 50.082, 14.440, 50.092]},
+        'crs': 'EPSG:4326',
+    },
+}
+
+_MOCK_COLLECTIONS_RESPONSE = {'collections': [{'id': 'insitu'}]}
+_MOCK_COLLECTION_DETAIL = {
+    'id': 'insitu',
+    'type': 'Collection',
+    'stac_version': '1.0.0',
+    'description': 'In-situ sensor data',
+    'links': [],
+    'extent': {
+        'spatial': {'bbox': [[-180, -90, 180, 90]]},
+        'temporal': {'interval': [[None, None]]},
+    },
+    'license': 'proprietary',
+}
+
+
+def _make_insitu_stac_json(meta: dict) -> str:
+    """Generate an insitu STAC item to a temp JSON file; return path."""
+    csv_content = 'iso_timestamp,lat,lon,pressure\n2026-01-01T00:00:00,50.082,14.412,101.3\n'
+    with tempfile.NamedTemporaryFile(
+        mode='w', suffix='.csv', delete=False
+    ) as csv_f:
+        csv_f.write(csv_content)
+        csv_path = csv_f.name
+
+    try:
+        ds = InsituDataset(csv_path, meta)
+        item = StacItemFactory(ds, MagicMock()).create_item()
+    finally:
+        os.unlink(csv_path)
+
+    with tempfile.NamedTemporaryFile(
+        mode='w', suffix='.json', delete=False
+    ) as json_f:
+        json.dump(item, json_f)
+        return json_f.name
+
+
+def _mock_requests_get(url, *args, **kwargs):
+    mock = MagicMock()
+    mock.raise_for_status = MagicMock()
+    if url.endswith('/collections'):
+        mock.json.return_value = _MOCK_COLLECTIONS_RESPONSE
+    else:
+        mock.json.return_value = _MOCK_COLLECTION_DETAIL
+    return mock
 
 
 def item_dict_no_datetime(item_dict):
@@ -288,4 +354,98 @@ class TestModules:
             )
         finally:
             # Cleanup
+            Path(tmp_path).unlink()
+
+    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    def test_MetadataValidator_001_insitu_valid(self, _mock):
+        """Test MetadataValidator with valid in-situ metadata."""
+        tmp_path = _make_insitu_stac_json(_INSITU_META)
+        try:
+            result = MetadataValidator().validate(tmp_path)
+            assert isinstance(result, dict)
+            assert result['valid'] is True
+            assert result['errors'] == []
+        finally:
+            Path(tmp_path).unlink()
+
+    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    def test_MetadataValidator_002_insitu_missing_time_range(self, _mock):
+        """Test MetadataValidator detects missing start_datetime / end_datetime."""
+        import copy
+        meta = copy.deepcopy(_INSITU_META)
+        del meta['data']['time_range']
+
+        tmp_path = _make_insitu_stac_json(meta)
+        try:
+            result = MetadataValidator().validate(tmp_path)
+            assert result['valid'] is False
+            assert any('start_datetime' in e for e in result['errors'])
+        finally:
+            Path(tmp_path).unlink()
+
+    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    def test_MetadataValidator_003_insitu_invalid_bbox(self, _mock):
+        """Test MetadataValidator detects bbox outside WGS-84 bounds."""
+        import copy
+        meta = copy.deepcopy(_INSITU_META)
+        meta['data']['location'] = {'bbox': [-200.0, 50.082, 14.440, 50.092]}
+
+        tmp_path = _make_insitu_stac_json(meta)
+        try:
+            result = MetadataValidator().validate(tmp_path)
+            assert result['valid'] is False
+            assert any('WGS-84' in e for e in result['errors'])
+        finally:
+            Path(tmp_path).unlink()
+
+    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    def test_MetadataValidator_004_insitu_start_after_end(self, _mock):
+        """Test MetadataValidator detects start_datetime >= end_datetime."""
+        import copy
+        meta = copy.deepcopy(_INSITU_META)
+        meta['data']['time_range'] = {
+            'start': '2026-06-30T23:59:59Z',
+            'end': '2026-01-01T00:00:00Z',
+        }
+
+        tmp_path = _make_insitu_stac_json(meta)
+        try:
+            result = MetadataValidator().validate(tmp_path)
+            assert result['valid'] is False
+            assert any('start_datetime' in e for e in result['errors'])
+        finally:
+            Path(tmp_path).unlink()
+
+    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    def test_MetadataValidator_005_insitu_missing_columns(self, _mock):
+        """Test MetadataValidator detects missing table:columns in assets.data."""
+        tmp_path = _make_insitu_stac_json(_INSITU_META)
+        try:
+            with open(tmp_path) as f:
+                item_dict = json.load(f)
+            item_dict['assets']['data'].pop('table:columns', None)
+            with open(tmp_path, 'w') as f:
+                json.dump(item_dict, f)
+
+            result = MetadataValidator().validate(tmp_path)
+            assert result['valid'] is False
+            assert any('table:columns' in e for e in result['errors'])
+        finally:
+            Path(tmp_path).unlink()
+
+    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    def test_MetadataValidator_006_insitu_invalid_datetime_format(self, _mock):
+        """Test MetadataValidator detects invalid datetime format in time range."""
+        tmp_path = _make_insitu_stac_json(_INSITU_META)
+        try:
+            with open(tmp_path) as f:
+                item_dict = json.load(f)
+            item_dict['properties']['start_datetime'] = 'not-a-datetime'
+            with open(tmp_path, 'w') as f:
+                json.dump(item_dict, f)
+
+            result = MetadataValidator().validate(tmp_path)
+            assert result['valid'] is False
+            assert any('datetime' in e.lower() for e in result['errors'])
+        finally:
             Path(tmp_path).unlink()

--- a/subsystems/dpr/tests/test_modules.py
+++ b/subsystems/dpr/tests/test_modules.py
@@ -48,10 +48,10 @@ _MOCK_COLLECTION_DETAIL = {
 
 def _make_insitu_stac_json(meta: dict) -> str:
     """Generate an insitu STAC item to a temp JSON file; return path."""
-    csv_content = 'iso_timestamp,lat,lon,pressure\n2026-01-01T00:00:00,50.082,14.412,101.3\n'
-    with tempfile.NamedTemporaryFile(
-        mode='w', suffix='.csv', delete=False
-    ) as csv_f:
+    csv_content = (
+        'iso_timestamp,lat,lon,pressure\n2026-01-01T00:00:00,50.082,14.412,101.3\n'
+    )
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as csv_f:
         csv_f.write(csv_content)
         csv_path = csv_f.name
 
@@ -61,9 +61,7 @@ def _make_insitu_stac_json(meta: dict) -> str:
     finally:
         os.unlink(csv_path)
 
-    with tempfile.NamedTemporaryFile(
-        mode='w', suffix='.json', delete=False
-    ) as json_f:
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as json_f:
         json.dump(item, json_f)
         return json_f.name
 
@@ -356,7 +354,10 @@ class TestModules:
             # Cleanup
             Path(tmp_path).unlink()
 
-    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    @patch(
+        'subsystems.dpr.metadata_processor.validator.requests.get',
+        side_effect=_mock_requests_get,
+    )
     def test_MetadataValidator_001_insitu_valid(self, _mock):
         """Test MetadataValidator with valid in-situ metadata."""
         tmp_path = _make_insitu_stac_json(_INSITU_META)
@@ -368,10 +369,14 @@ class TestModules:
         finally:
             Path(tmp_path).unlink()
 
-    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    @patch(
+        'subsystems.dpr.metadata_processor.validator.requests.get',
+        side_effect=_mock_requests_get,
+    )
     def test_MetadataValidator_002_insitu_missing_time_range(self, _mock):
         """Test MetadataValidator detects missing start_datetime / end_datetime."""
         import copy
+
         meta = copy.deepcopy(_INSITU_META)
         del meta['data']['time_range']
 
@@ -383,10 +388,14 @@ class TestModules:
         finally:
             Path(tmp_path).unlink()
 
-    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    @patch(
+        'subsystems.dpr.metadata_processor.validator.requests.get',
+        side_effect=_mock_requests_get,
+    )
     def test_MetadataValidator_003_insitu_invalid_bbox(self, _mock):
         """Test MetadataValidator detects bbox outside WGS-84 bounds."""
         import copy
+
         meta = copy.deepcopy(_INSITU_META)
         meta['data']['location'] = {'bbox': [-200.0, 50.082, 14.440, 50.092]}
 
@@ -398,10 +407,14 @@ class TestModules:
         finally:
             Path(tmp_path).unlink()
 
-    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    @patch(
+        'subsystems.dpr.metadata_processor.validator.requests.get',
+        side_effect=_mock_requests_get,
+    )
     def test_MetadataValidator_004_insitu_start_after_end(self, _mock):
         """Test MetadataValidator detects start_datetime >= end_datetime."""
         import copy
+
         meta = copy.deepcopy(_INSITU_META)
         meta['data']['time_range'] = {
             'start': '2026-06-30T23:59:59Z',
@@ -416,7 +429,10 @@ class TestModules:
         finally:
             Path(tmp_path).unlink()
 
-    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    @patch(
+        'subsystems.dpr.metadata_processor.validator.requests.get',
+        side_effect=_mock_requests_get,
+    )
     def test_MetadataValidator_005_insitu_missing_columns(self, _mock):
         """Test MetadataValidator detects missing table:columns in assets.data."""
         tmp_path = _make_insitu_stac_json(_INSITU_META)
@@ -433,7 +449,10 @@ class TestModules:
         finally:
             Path(tmp_path).unlink()
 
-    @patch('subsystems.dpr.metadata_processor.validator.requests.get', side_effect=_mock_requests_get)
+    @patch(
+        'subsystems.dpr.metadata_processor.validator.requests.get',
+        side_effect=_mock_requests_get,
+    )
     def test_MetadataValidator_006_insitu_invalid_datetime_format(self, _mock):
         """Test MetadataValidator detects invalid datetime format in time range."""
         tmp_path = _make_insitu_stac_json(_INSITU_META)


### PR DESCRIPTION
## Summary

Extends `MetadataValidator` to support in-situ (CSV-based) STAC items, as requested in #404.

Previously the validator only handled EO raster items. In-situ items generated by `InsituDataset` now go through a dedicated validation path.

## Approach

Uses a JSON Schema + Python hybrid:

- **`schemas/insitu.json`**, GAIA-defined schema for in-situ STAC items (no official STAC extension exists for tabular sensor data). Enforces presence and format of `start_datetime`/`end_datetime` and requires `assets.data.table:columns`.
- **Python rules**, two checks that cannot be expressed in JSON Schema: `start_datetime < end_datetime`, and bbox within WGS-84 bounds (`lon: -180..180`, `lat: -90..90`).

## Changes

- `subsystems/dpr/metadata_processor/validator.py`, adds `_is_insitu()` detection and `_validate_insitu()` logic
- `subsystems/dpr/metadata_processor/schemas/insitu.json`, new GAIA insitu schema
- `subsystems/dpr/tests/test_modules.py`, 6 new unit tests covering valid input and all failure modes


Closes #404