### PR TITLE
CI: Add test results artifact upload to pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -266,3 +266,17 @@ jobs:
             docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/geneneral.xml $i
             cd ..
           done
+
+  upload-test-results:
+    runs-on: ubuntu-24.04
+    needs: [ale, dag, dpr, eou, isu, map, ntf, qcl, rep, sdi, vid, general]
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Upload test results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: tests/results/
+          compression-level: 6

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,7 @@ jobs:
           for i in $(ls subsystems/ale/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/ale.xml $i
             cd ..
           done
 
@@ -55,7 +55,7 @@ jobs:
           for i in $(ls subsystems/dag/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/dag.xml $i
             cd ..
           done
 
@@ -79,7 +79,7 @@ jobs:
           for i in $(ls subsystems/dpr/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -vv $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/dpr.xml $i
             cd ..
           done
 
@@ -103,7 +103,7 @@ jobs:
           for i in $(ls subsystems/eou/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/eou.xml $i
             cd ..
           done
 
@@ -123,7 +123,7 @@ jobs:
           for i in $(ls subsystems/isu/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/isu.xml $i
             cd ..
           done
 
@@ -143,7 +143,7 @@ jobs:
           for i in $(ls subsystems/map/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/map.xml $i
             cd ..
           done
 
@@ -163,7 +163,7 @@ jobs:
           for i in $(ls subsystems/ntf/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/ntf.xml $i
             cd ..
           done
 
@@ -183,7 +183,7 @@ jobs:
           for i in $(ls subsystems/qcl/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/qcl.xml $i
             cd ..
           done
 
@@ -203,7 +203,7 @@ jobs:
           for i in $(ls subsystems/rep/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/rep.xml $i
             cd ..
           done
 
@@ -223,7 +223,7 @@ jobs:
           for i in $(ls subsystems/sdi/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/sdi.xml $i
             cd ..
           done
 
@@ -243,7 +243,7 @@ jobs:
           for i in $(ls subsystems/vid/tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/vid.xml $i
             cd ..
           done
 
@@ -263,6 +263,6 @@ jobs:
           for i in $(ls tests/test*py); do
             echo "*** running test suite: $i ***"
             cd docker
-            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v $i
+            docker compose exec -u $(id -u):$(id -g) gaiatesting python3 -m pytest -v --junitxml=tests/results/geneneral.xml $i
             cd ..
           done

--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ config.yaml
 tests/data/*
 venv/
 *.swp
+tests/results/


### PR DESCRIPTION
### Summary
Adds a final job to the CI/CD pipeline that uploads test results from all subsystem tests as a zipped GitHub artifact after the workflow completes.

### Changes
- New `upload-test-results` job that runs after all subsystem tests (ale, dag, dpr, eou, isu, map, ntf, qcl, rep, sdi, vid, general)
- Automatically uploads `tests/results/` directory as artifact with compression
- Archive name: `pytest-results`

### Benefits
- Easily download and review all test results from CI runs
- Better visibility into test outcomes across all subsystems
- Centralized test artifact storage for debugging and analysis
